### PR TITLE
[FEAT] Implement an function to get all genres as map

### DIFF
--- a/src/main/java/net/ow/movie/theatre/service/GenreService.java
+++ b/src/main/java/net/ow/movie/theatre/service/GenreService.java
@@ -18,7 +18,7 @@ public class GenreService {
 
     private final GenreDTOMapper genreDTOMapper;
 
-    public List<GenreDTO> getGenres(String language) {
+    public List<GenreDTO> getAllGenres(String language) {
         log.debug("Fetching genres from TMDB");
         TMDBGenreList tmdbGenreList = tmdbFeignClient.getGenres(language);
         log.debug("Fetched genres from TMDB");
@@ -26,11 +26,18 @@ public class GenreService {
         return genreDTOMapper.from(tmdbGenreList);
     }
 
-    public List<GenreDTO> getGenresByIds(List<Integer> ids, String language) {
-        List<GenreDTO> genres = getGenres(language);
-        Map<Integer, GenreDTO> tmdbGenresMap =
-                genres.stream().collect(Collectors.toMap(GenreDTO::getId, genre -> genre));
+    public Map<Integer, GenreDTO> getAllGenresAsMap(String language) {
+        List<GenreDTO> genres = getAllGenres(language);
+        return genres.stream()
+                .collect(
+                        Collectors.toMap(
+                                GenreDTO::getId,
+                                genre -> genre,
+                                (existing, replacement) -> replacement));
+    }
 
+    public List<GenreDTO> findGenresByIds(List<Integer> ids, String language) {
+        Map<Integer, GenreDTO> tmdbGenresMap = getAllGenresAsMap(language);
         return ids.stream().distinct().map(tmdbGenresMap::get).filter(Objects::nonNull).toList();
     }
 }

--- a/src/test/java/net/ow/movie/theatre/service/GenreServiceTest.java
+++ b/src/test/java/net/ow/movie/theatre/service/GenreServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import net.ow.movie.theatre.dto.genre.GenreDTO;
 import net.ow.movie.theatre.mapper.genre.GenreDTOMapper;
 import net.ow.movie.tmdb.feign.TMDBFeignClient;
@@ -31,7 +32,7 @@ class GenreServiceTest {
     @Mock private GenreDTO genre2;
 
     @Test
-    void getGenresTest_OK() {
+    void getAllGenresTest_OK() {
         String language = "zh-CN";
 
         List<GenreDTO> genres = List.of(genre1, genre2);
@@ -39,7 +40,7 @@ class GenreServiceTest {
         when(tmdbFeignClient.getGenres(language)).thenReturn(tmdbGenreList);
         when(genreDTOMapper.from(tmdbGenreList)).thenReturn(genres);
 
-        List<GenreDTO> actualGenres = genreService.getGenres(language);
+        List<GenreDTO> actualGenres = genreService.getAllGenres(language);
 
         assertEquals(genres, actualGenres);
         verify(tmdbFeignClient, times(1)).getGenres(language);
@@ -47,7 +48,7 @@ class GenreServiceTest {
     }
 
     @Test
-    void getGenresByIds_OK() {
+    void getAllGenresAsMapTest_OK() {
         String language = "zh-CN";
 
         when(genre1.getId()).thenReturn(1);
@@ -57,7 +58,63 @@ class GenreServiceTest {
         when(tmdbFeignClient.getGenres(language)).thenReturn(tmdbGenreList);
         when(genreDTOMapper.from(tmdbGenreList)).thenReturn(genres);
 
-        List<GenreDTO> actualGenres = genreService.getGenresByIds(List.of(1, 2), language);
+        Map<Integer, GenreDTO> genreMap = genreService.getAllGenresAsMap(language);
+
+        assertEquals(2, genreMap.size());
+        assertTrue(genreMap.containsKey(1));
+        assertTrue(genreMap.containsKey(2));
+        assertEquals(genre1, genreMap.get(1));
+        assertEquals(genre2, genreMap.get(2));
+        verify(tmdbFeignClient, times(1)).getGenres(language);
+        verify(genreDTOMapper, times(1)).from(tmdbGenreList);
+    }
+
+    @Test
+    void getAllGenresAsMapTest_whenEmptyList_thenReturnsEmptyMap() {
+        String language = "zh-CN";
+
+        when(tmdbFeignClient.getGenres(language)).thenReturn(tmdbGenreList);
+        when(genreDTOMapper.from(tmdbGenreList)).thenReturn(Collections.emptyList());
+
+        Map<Integer, GenreDTO> genreMap = genreService.getAllGenresAsMap(language);
+
+        assertTrue(genreMap.isEmpty());
+        verify(tmdbFeignClient, times(1)).getGenres(language);
+        verify(genreDTOMapper, times(1)).from(tmdbGenreList);
+    }
+
+    @Test
+    void getAllGenresAsMapTest_whenDuplicateIds_thenReturnsUniqueGenres() {
+        String language = "zh-CN";
+
+        when(genre1.getId()).thenReturn(1);
+        when(genre2.getId()).thenReturn(1);
+        List<GenreDTO> genres = List.of(genre1, genre2);
+
+        when(tmdbFeignClient.getGenres(language)).thenReturn(tmdbGenreList);
+        when(genreDTOMapper.from(tmdbGenreList)).thenReturn(genres);
+
+        Map<Integer, GenreDTO> genreMap = genreService.getAllGenresAsMap(language);
+
+        assertEquals(1, genreMap.size());
+        assertTrue(genreMap.containsKey(1));
+        assertEquals(genre2, genreMap.get(1));
+        verify(tmdbFeignClient, times(1)).getGenres(language);
+        verify(genreDTOMapper, times(1)).from(tmdbGenreList);
+    }
+
+    @Test
+    void findGenresByIdsTest_OK() {
+        String language = "zh-CN";
+
+        when(genre1.getId()).thenReturn(1);
+        when(genre2.getId()).thenReturn(2);
+        List<GenreDTO> genres = List.of(genre1, genre2);
+
+        when(tmdbFeignClient.getGenres(language)).thenReturn(tmdbGenreList);
+        when(genreDTOMapper.from(tmdbGenreList)).thenReturn(genres);
+
+        List<GenreDTO> actualGenres = genreService.findGenresByIds(List.of(1, 2), language);
 
         assertEquals(2, actualGenres.size());
         assertTrue(actualGenres.containsAll(genres));
@@ -66,7 +123,7 @@ class GenreServiceTest {
     }
 
     @Test
-    void getGenresByIdsTest_whenEmptyIdsList_thenReturnsEmptyList() {
+    void findGenresByIdsTest_whenEmptyIdsList_thenReturnsEmptyList() {
         String language = "zh-CN";
 
         when(genre1.getId()).thenReturn(1);
@@ -77,7 +134,7 @@ class GenreServiceTest {
         when(genreDTOMapper.from(tmdbGenreList)).thenReturn(genres);
 
         List<GenreDTO> actualGenres =
-                genreService.getGenresByIds(Collections.emptyList(), language);
+                genreService.findGenresByIds(Collections.emptyList(), language);
 
         assertTrue(actualGenres.isEmpty());
         verify(tmdbFeignClient, times(1)).getGenres(language);
@@ -85,7 +142,7 @@ class GenreServiceTest {
     }
 
     @Test
-    void getGenresByIdsTest_whenInvalidIds_thenReturnsEmptyList() {
+    void findGenresByIdsTest_whenInvalidIds_thenReturnsEmptyList() {
         String language = "zh-CN";
 
         when(genre1.getId()).thenReturn(1);
@@ -95,7 +152,7 @@ class GenreServiceTest {
         when(tmdbFeignClient.getGenres(language)).thenReturn(tmdbGenreList);
         when(genreDTOMapper.from(tmdbGenreList)).thenReturn(genres);
 
-        List<GenreDTO> actualGenres = genreService.getGenresByIds(List.of(3, 4), language);
+        List<GenreDTO> actualGenres = genreService.findGenresByIds(List.of(3, 4), language);
 
         assertTrue(actualGenres.isEmpty());
         verify(tmdbFeignClient, times(1)).getGenres(language);
@@ -103,7 +160,7 @@ class GenreServiceTest {
     }
 
     @Test
-    void getGenresByIdsTest_whenDuplicateIds_thenReturnsUniqueGenres() {
+    void findGenresByIdsTest_whenDuplicateIds_thenReturnsUniqueGenres() {
         String language = "zh-CN";
 
         when(genre1.getId()).thenReturn(1);
@@ -113,7 +170,7 @@ class GenreServiceTest {
         when(tmdbFeignClient.getGenres(language)).thenReturn(tmdbGenreList);
         when(genreDTOMapper.from(tmdbGenreList)).thenReturn(genres);
 
-        List<GenreDTO> actualGenres = genreService.getGenresByIds(List.of(1, 1, 2), language);
+        List<GenreDTO> actualGenres = genreService.findGenresByIds(List.of(1, 1, 2), language);
 
         assertEquals(2, actualGenres.size());
         assertTrue(actualGenres.containsAll(genres));


### PR DESCRIPTION
## Description

- Implement an function to get all genres as map
- Rename function in GenreService

## Checklist

- [x] I have performed a self-review of my own code
- [x] This PR does not introduce a breaking change
- [x] Unit tests are added/updated (if applicable)
- [x] No error nor warning in the console
- [ ] I have uploaded a screenshot (if applicable)

