### PR TITLE
[RFT] Rename the functions in all mappers to indicate the source object in the function name

### DIFF
--- a/src/main/java/net/ow/movie/theatre/mapper/genre/GenreDTOMapper.java
+++ b/src/main/java/net/ow/movie/theatre/mapper/genre/GenreDTOMapper.java
@@ -13,7 +13,7 @@ import org.mapstruct.*;
         nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT,
         unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface GenreDTOMapper {
-    default List<GenreDTO> from(TMDBGenreList tmdbGenreList) {
+    default List<GenreDTO> fromTMDBGenreList(TMDBGenreList tmdbGenreList) {
         if (null == tmdbGenreList) {
             return Collections.emptyList();
         }
@@ -23,8 +23,8 @@ public interface GenreDTOMapper {
             return Collections.emptyList();
         }
 
-        return from(tmdbGenres);
+        return fromTMDBGenres(tmdbGenres);
     }
 
-    List<GenreDTO> from(List<TMDBGenre> tmdbGenres);
+    List<GenreDTO> fromTMDBGenres(List<TMDBGenre> tmdbGenres);
 }

--- a/src/main/java/net/ow/movie/theatre/mapper/movie/BaseMovieDTOMapper.java
+++ b/src/main/java/net/ow/movie/theatre/mapper/movie/BaseMovieDTOMapper.java
@@ -13,10 +13,10 @@ import org.mapstruct.*;
         unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface BaseMovieDTOMapper {
     @Mapping(target = "name", source = "title")
-    BaseMovieDTO from(TMDBBaseMovie tmdbBaseMovie);
+    BaseMovieDTO fromTMDBBaseMovie(TMDBBaseMovie tmdbBaseMovie);
 
     @Mapping(target = "data", source = "results")
     @Mapping(target = "total", source = "totalResults")
-    PaginatedResponse<BaseMovieDTO> from(
+    PaginatedResponse<BaseMovieDTO> fromTMDBPaginatedBaseMovies(
             TMDBPaginatedResponse<TMDBBaseMovie> tmdbPaginatedResponse);
 }

--- a/src/main/java/net/ow/movie/theatre/mapper/search/MovieSearchResultDTOMapper.java
+++ b/src/main/java/net/ow/movie/theatre/mapper/search/MovieSearchResultDTOMapper.java
@@ -13,5 +13,5 @@ import org.mapstruct.ReportingPolicy;
         nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT,
         unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface MovieSearchResultDTOMapper {
-    MovieSearchResultDTO from(TMDBMovieSearchResult tmdbMovieSearchResult);
+    MovieSearchResultDTO fromTMDBMovieSearchResult(TMDBMovieSearchResult tmdbMovieSearchResult);
 }

--- a/src/main/java/net/ow/movie/theatre/mapper/search/PersonSearchResultDTOMapper.java
+++ b/src/main/java/net/ow/movie/theatre/mapper/search/PersonSearchResultDTOMapper.java
@@ -13,5 +13,5 @@ import org.mapstruct.ReportingPolicy;
         nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT,
         unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface PersonSearchResultDTOMapper {
-    PersonSearchResultDTO from(TMDBPersonSearchResult tmdbPersonSearchResult);
+    PersonSearchResultDTO fromTMDBPersonSearchResult(TMDBPersonSearchResult tmdbPersonSearchResult);
 }

--- a/src/main/java/net/ow/movie/theatre/mapper/search/SearchResultDTOMapper.java
+++ b/src/main/java/net/ow/movie/theatre/mapper/search/SearchResultDTOMapper.java
@@ -26,10 +26,10 @@ public interface SearchResultDTOMapper {
     @SubclassMapping(target = MovieSearchResultDTO.class, source = TMDBMovieSearchResult.class)
     @SubclassMapping(target = TVSearchResultDTO.class, source = TMDBTVSearchResult.class)
     @SubclassMapping(target = PersonSearchResultDTO.class, source = TMDBPersonSearchResult.class)
-    SearchResultDTO from(TMDBSearchResult tmdbSearchResult);
+    SearchResultDTO fromTMDBSearchResult(TMDBSearchResult tmdbSearchResult);
 
     @Mapping(target = "data", source = "results")
     @Mapping(target = "total", source = "totalResults")
-    PaginatedResponse<SearchResultDTO> from(
+    PaginatedResponse<SearchResultDTO> fromTMDBPaginatedSearchResults(
             TMDBPaginatedResponse<TMDBSearchResult> tmdbPaginatedResponse);
 }

--- a/src/main/java/net/ow/movie/theatre/mapper/search/TVSearchResultDTOMapper.java
+++ b/src/main/java/net/ow/movie/theatre/mapper/search/TVSearchResultDTOMapper.java
@@ -13,5 +13,5 @@ import org.mapstruct.ReportingPolicy;
         nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT,
         unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface TVSearchResultDTOMapper {
-    TVSearchResultDTO from(TMDBTVSearchResult tmdbtvSearchResult);
+    TVSearchResultDTO fromTMDBTVSearchResult(TMDBTVSearchResult tmdbtvSearchResult);
 }

--- a/src/main/java/net/ow/movie/theatre/service/GenreService.java
+++ b/src/main/java/net/ow/movie/theatre/service/GenreService.java
@@ -23,7 +23,7 @@ public class GenreService {
         TMDBGenreList tmdbGenreList = tmdbFeignClient.getGenres(language);
         log.debug("Fetched genres from TMDB");
 
-        return genreDTOMapper.from(tmdbGenreList);
+        return genreDTOMapper.fromTMDBGenreList(tmdbGenreList);
     }
 
     public Map<Integer, GenreDTO> getAllGenresAsMap(String language) {

--- a/src/main/java/net/ow/movie/theatre/service/MovieService.java
+++ b/src/main/java/net/ow/movie/theatre/service/MovieService.java
@@ -33,7 +33,7 @@ public class MovieService {
         log.debug("Fetched popular movie from tmdb");
 
         PaginatedResponse<BaseMovieDTO> paginatedResponse =
-                baseMovieDTOMapper.from(tmdbPaginatedResponse);
+                baseMovieDTOMapper.fromTMDBPaginatedBaseMovies(tmdbPaginatedResponse);
         if (null == paginatedResponse || null == paginatedResponse.getData()) {
             return paginatedResponse;
         }

--- a/src/main/java/net/ow/movie/theatre/service/SearchService.java
+++ b/src/main/java/net/ow/movie/theatre/service/SearchService.java
@@ -26,6 +26,6 @@ public class SearchService {
                 tmdbFeignClient.search(query, TMDBConstant.INCLUDE_ADULT, language, pageNumber);
         log.debug("Searched \"{}\" from tmdb", query);
 
-        return searchResultDTOMapper.from(tmdbPaginatedResponse);
+        return searchResultDTOMapper.fromTMDBPaginatedSearchResults(tmdbPaginatedResponse);
     }
 }

--- a/src/test/java/net/ow/movie/theatre/mapper/genre/GenreDTOMapperTest.java
+++ b/src/test/java/net/ow/movie/theatre/mapper/genre/GenreDTOMapperTest.java
@@ -21,7 +21,7 @@ class GenreDTOMapperTest {
         TMDBGenre tmdbGenre = MockTMDBGenre.mock(genreId);
         TMDBGenreList tmdbGenreList = MockTMDBGenreList.mock(List.of(tmdbGenre));
 
-        List<GenreDTO> result = genreDTOMapper.from(tmdbGenreList);
+        List<GenreDTO> result = genreDTOMapper.fromTMDBGenreList(tmdbGenreList);
         assertEquals(1, result.size(), "Expected one GenreDTO in the result");
         assertEquals(genreId, result.get(0).getId(), "Expected GenreDTO id to be 1");
         assertEquals("Action", result.get(0).getName(), "Expected GenreDTO name to be 'Action'");
@@ -29,7 +29,7 @@ class GenreDTOMapperTest {
 
     @Test
     void fromTest_whenTMDBGenreListNull_thenReturnsEmptyList() {
-        List<GenreDTO> result = genreDTOMapper.from((TMDBGenreList) null);
+        List<GenreDTO> result = genreDTOMapper.fromTMDBGenreList(null);
 
         assertTrue(result.isEmpty(), "Expected an empty list for null input");
     }
@@ -38,7 +38,7 @@ class GenreDTOMapperTest {
     void fromTest_whenGenresListIsNull_thenReturnsEmptyList() {
         TMDBGenreList tmdbGenreList = MockTMDBGenreList.mock(null);
 
-        List<GenreDTO> result = genreDTOMapper.from(tmdbGenreList);
+        List<GenreDTO> result = genreDTOMapper.fromTMDBGenreList(tmdbGenreList);
         assertTrue(result.isEmpty(), "Expected an empty list for null genres list");
     }
 }

--- a/src/test/java/net/ow/movie/theatre/service/GenreServiceTest.java
+++ b/src/test/java/net/ow/movie/theatre/service/GenreServiceTest.java
@@ -38,13 +38,13 @@ class GenreServiceTest {
         List<GenreDTO> genres = List.of(genre1, genre2);
 
         when(tmdbFeignClient.getGenres(language)).thenReturn(tmdbGenreList);
-        when(genreDTOMapper.from(tmdbGenreList)).thenReturn(genres);
+        when(genreDTOMapper.fromTMDBGenreList(tmdbGenreList)).thenReturn(genres);
 
         List<GenreDTO> actualGenres = genreService.getAllGenres(language);
 
         assertEquals(genres, actualGenres);
         verify(tmdbFeignClient, times(1)).getGenres(language);
-        verify(genreDTOMapper, times(1)).from(tmdbGenreList);
+        verify(genreDTOMapper, times(1)).fromTMDBGenreList(tmdbGenreList);
     }
 
     @Test
@@ -56,7 +56,7 @@ class GenreServiceTest {
         List<GenreDTO> genres = List.of(genre1, genre2);
 
         when(tmdbFeignClient.getGenres(language)).thenReturn(tmdbGenreList);
-        when(genreDTOMapper.from(tmdbGenreList)).thenReturn(genres);
+        when(genreDTOMapper.fromTMDBGenreList(tmdbGenreList)).thenReturn(genres);
 
         Map<Integer, GenreDTO> genreMap = genreService.getAllGenresAsMap(language);
 
@@ -66,7 +66,7 @@ class GenreServiceTest {
         assertEquals(genre1, genreMap.get(1));
         assertEquals(genre2, genreMap.get(2));
         verify(tmdbFeignClient, times(1)).getGenres(language);
-        verify(genreDTOMapper, times(1)).from(tmdbGenreList);
+        verify(genreDTOMapper, times(1)).fromTMDBGenreList(tmdbGenreList);
     }
 
     @Test
@@ -74,13 +74,13 @@ class GenreServiceTest {
         String language = "zh-CN";
 
         when(tmdbFeignClient.getGenres(language)).thenReturn(tmdbGenreList);
-        when(genreDTOMapper.from(tmdbGenreList)).thenReturn(Collections.emptyList());
+        when(genreDTOMapper.fromTMDBGenreList(tmdbGenreList)).thenReturn(Collections.emptyList());
 
         Map<Integer, GenreDTO> genreMap = genreService.getAllGenresAsMap(language);
 
         assertTrue(genreMap.isEmpty());
         verify(tmdbFeignClient, times(1)).getGenres(language);
-        verify(genreDTOMapper, times(1)).from(tmdbGenreList);
+        verify(genreDTOMapper, times(1)).fromTMDBGenreList(tmdbGenreList);
     }
 
     @Test
@@ -92,7 +92,7 @@ class GenreServiceTest {
         List<GenreDTO> genres = List.of(genre1, genre2);
 
         when(tmdbFeignClient.getGenres(language)).thenReturn(tmdbGenreList);
-        when(genreDTOMapper.from(tmdbGenreList)).thenReturn(genres);
+        when(genreDTOMapper.fromTMDBGenreList(tmdbGenreList)).thenReturn(genres);
 
         Map<Integer, GenreDTO> genreMap = genreService.getAllGenresAsMap(language);
 
@@ -100,7 +100,7 @@ class GenreServiceTest {
         assertTrue(genreMap.containsKey(1));
         assertEquals(genre2, genreMap.get(1));
         verify(tmdbFeignClient, times(1)).getGenres(language);
-        verify(genreDTOMapper, times(1)).from(tmdbGenreList);
+        verify(genreDTOMapper, times(1)).fromTMDBGenreList(tmdbGenreList);
     }
 
     @Test

--- a/src/test/java/net/ow/movie/theatre/service/MovieServiceTest.java
+++ b/src/test/java/net/ow/movie/theatre/service/MovieServiceTest.java
@@ -66,7 +66,8 @@ class MovieServiceTest {
 
         when(tmdbFeignClient.getPopularMovies(language, page, region))
                 .thenReturn(tmdbPaginatedResponse);
-        when(baseMovieDTOMapper.from(tmdbPaginatedResponse)).thenReturn(paginatedResponse);
+        when(baseMovieDTOMapper.fromTMDBPaginatedBaseMovies(tmdbPaginatedResponse))
+                .thenReturn(paginatedResponse);
         when(genreService.getAllGenresAsMap(language)).thenReturn(genreIdToGenreMap);
         when(genreService.findGenresByIds(genreIds, genreIdToGenreMap)).thenReturn(genres);
 
@@ -87,7 +88,7 @@ class MovieServiceTest {
         String region = "CH";
 
         when(tmdbFeignClient.getPopularMovies(language, page, region)).thenReturn(null);
-        when(baseMovieDTOMapper.from((TMDBPaginatedResponse<TMDBBaseMovie>) null)).thenReturn(null);
+        when(baseMovieDTOMapper.fromTMDBPaginatedBaseMovies(null)).thenReturn(null);
 
         PaginatedResponse<BaseMovieDTO> actualResponse =
                 movieService.getPopularMovies(language, page, region);
@@ -106,7 +107,8 @@ class MovieServiceTest {
 
         when(tmdbFeignClient.getPopularMovies(language, page, region))
                 .thenReturn(tmdbPaginatedResponse);
-        when(baseMovieDTOMapper.from(tmdbPaginatedResponse)).thenReturn(paginatedResponse);
+        when(baseMovieDTOMapper.fromTMDBPaginatedBaseMovies(tmdbPaginatedResponse))
+                .thenReturn(paginatedResponse);
 
         PaginatedResponse<BaseMovieDTO> actualResponse =
                 movieService.getPopularMovies(language, page, region);

--- a/src/test/java/net/ow/movie/theatre/service/SearchServiceTest.java
+++ b/src/test/java/net/ow/movie/theatre/service/SearchServiceTest.java
@@ -34,13 +34,14 @@ class SearchServiceTest {
         String language = "en-US";
 
         when(tmdbFeignClient.search(query, true, language, page)).thenReturn(tmdbPaginatedResponse);
-        when(searchResultDTOMapper.from(tmdbPaginatedResponse)).thenReturn(paginatedResponse);
+        when(searchResultDTOMapper.fromTMDBPaginatedSearchResults(tmdbPaginatedResponse))
+                .thenReturn(paginatedResponse);
 
         PaginatedResponse<SearchResultDTO> actualPaginatedResponse =
                 searchService.search(query, page, language);
 
         assertEquals(actualPaginatedResponse, paginatedResponse);
         verify(tmdbFeignClient, times(1)).search(query, true, language, page);
-        verify(searchResultDTOMapper, times(1)).from(tmdbPaginatedResponse);
+        verify(searchResultDTOMapper, times(1)).fromTMDBPaginatedSearchResults(tmdbPaginatedResponse);
     }
 }

--- a/src/test/java/net/ow/movie/theatre/service/SearchServiceTest.java
+++ b/src/test/java/net/ow/movie/theatre/service/SearchServiceTest.java
@@ -42,6 +42,7 @@ class SearchServiceTest {
 
         assertEquals(actualPaginatedResponse, paginatedResponse);
         verify(tmdbFeignClient, times(1)).search(query, true, language, page);
-        verify(searchResultDTOMapper, times(1)).fromTMDBPaginatedSearchResults(tmdbPaginatedResponse);
+        verify(searchResultDTOMapper, times(1))
+                .fromTMDBPaginatedSearchResults(tmdbPaginatedResponse);
     }
 }


### PR DESCRIPTION
## Description

- Rename the functions in all mappers to indicate the source object in the function name

## Checklist

- [x] I have performed a self-review of my own code
- [x] This PR does not introduce a breaking change
- [x] Unit tests are added/updated (if applicable)
- [x] No error nor warning in the console
- [ ] I have uploaded a screenshot (if applicable)

