### PR TITLE
[RFT] Migrate all PaginatedRespone related mapping from different mappers to PaginatedResponseMapper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,7 @@
                             <exclude>**/model/**/*</exclude>
                             <exclude>**/mapper/search/*</exclude>
                             <exclude>**/mapper/movie/*</exclude>
+                            <exclude>**/mapper/PaginatedResponseMapper*.*</exclude>
                             <exclude>**/controller/**/*</exclude>
                             <exclude>**/MovieTheatreApplication.*</exclude>
                         </excludes>

--- a/src/main/java/net/ow/movie/theatre/mapper/PaginatedResponseMapper.java
+++ b/src/main/java/net/ow/movie/theatre/mapper/PaginatedResponseMapper.java
@@ -1,0 +1,30 @@
+package net.ow.movie.theatre.mapper;
+
+import net.ow.movie.theatre.dto.movie.BaseMovieDTO;
+import net.ow.movie.theatre.dto.pagination.PaginatedResponse;
+import net.ow.movie.theatre.dto.search.SearchResultDTO;
+import net.ow.movie.theatre.mapper.movie.BaseMovieDTOMapper;
+import net.ow.movie.theatre.mapper.search.SearchResultDTOMapper;
+import net.ow.movie.tmdb.model.common.TMDBPaginatedResponse;
+import net.ow.movie.tmdb.model.movie.TMDBBaseMovie;
+import net.ow.movie.tmdb.model.search.TMDBSearchResult;
+import org.mapstruct.*;
+
+@Mapper(
+        componentModel = "spring",
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+        nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT,
+        nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT,
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        uses = {SearchResultDTOMapper.class, BaseMovieDTOMapper.class})
+public interface PaginatedResponseMapper {
+    @Mapping(target = "data", source = "results")
+    @Mapping(target = "total", source = "totalResults")
+    PaginatedResponse<SearchResultDTO> fromTMDBPaginatedSearchResults(
+            TMDBPaginatedResponse<TMDBSearchResult> tmdbPaginatedResponse);
+
+    @Mapping(target = "data", source = "results")
+    @Mapping(target = "total", source = "totalResults")
+    PaginatedResponse<BaseMovieDTO> fromTMDBPaginatedBaseMovies(
+            TMDBPaginatedResponse<TMDBBaseMovie> tmdbPaginatedResponse);
+}

--- a/src/main/java/net/ow/movie/theatre/mapper/movie/BaseMovieDTOMapper.java
+++ b/src/main/java/net/ow/movie/theatre/mapper/movie/BaseMovieDTOMapper.java
@@ -1,9 +1,7 @@
 package net.ow.movie.theatre.mapper.movie;
 
 import net.ow.movie.theatre.dto.movie.BaseMovieDTO;
-import net.ow.movie.theatre.dto.pagination.PaginatedResponse;
 import net.ow.movie.theatre.mapper.genre.GenreDTOMapper;
-import net.ow.movie.tmdb.model.common.TMDBPaginatedResponse;
 import net.ow.movie.tmdb.model.movie.TMDBBaseMovie;
 import org.mapstruct.*;
 
@@ -18,9 +16,4 @@ public interface BaseMovieDTOMapper {
     @Mapping(target = "name", source = "title")
     @Mapping(target = "genres", source = "genreIds")
     BaseMovieDTO fromTMDBBaseMovie(TMDBBaseMovie tmdbBaseMovie);
-
-    @Mapping(target = "data", source = "results")
-    @Mapping(target = "total", source = "totalResults")
-    PaginatedResponse<BaseMovieDTO> fromTMDBPaginatedBaseMovies(
-            TMDBPaginatedResponse<TMDBBaseMovie> tmdbPaginatedResponse);
 }

--- a/src/main/java/net/ow/movie/theatre/mapper/search/SearchResultDTOMapper.java
+++ b/src/main/java/net/ow/movie/theatre/mapper/search/SearchResultDTOMapper.java
@@ -1,11 +1,9 @@
 package net.ow.movie.theatre.mapper.search;
 
-import net.ow.movie.theatre.dto.pagination.PaginatedResponse;
 import net.ow.movie.theatre.dto.search.MovieSearchResultDTO;
 import net.ow.movie.theatre.dto.search.PersonSearchResultDTO;
 import net.ow.movie.theatre.dto.search.SearchResultDTO;
 import net.ow.movie.theatre.dto.search.TVShowSearchResultDTO;
-import net.ow.movie.tmdb.model.common.TMDBPaginatedResponse;
 import net.ow.movie.tmdb.model.search.TMDBMovieSearchResult;
 import net.ow.movie.tmdb.model.search.TMDBPersonSearchResult;
 import net.ow.movie.tmdb.model.search.TMDBSearchResult;
@@ -28,9 +26,4 @@ public interface SearchResultDTOMapper {
     @SubclassMapping(target = TVShowSearchResultDTO.class, source = TMDBTVShowSearchResult.class)
     @SubclassMapping(target = PersonSearchResultDTO.class, source = TMDBPersonSearchResult.class)
     SearchResultDTO fromTMDBSearchResult(TMDBSearchResult tmdbSearchResult);
-
-    @Mapping(target = "data", source = "results")
-    @Mapping(target = "total", source = "totalResults")
-    PaginatedResponse<SearchResultDTO> fromTMDBPaginatedSearchResults(
-            TMDBPaginatedResponse<TMDBSearchResult> tmdbPaginatedResponse);
 }

--- a/src/main/java/net/ow/movie/theatre/service/MovieService.java
+++ b/src/main/java/net/ow/movie/theatre/service/MovieService.java
@@ -7,7 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.ow.movie.theatre.dto.genre.GenreDTO;
 import net.ow.movie.theatre.dto.movie.BaseMovieDTO;
 import net.ow.movie.theatre.dto.pagination.PaginatedResponse;
-import net.ow.movie.theatre.mapper.movie.BaseMovieDTOMapper;
+import net.ow.movie.theatre.mapper.PaginatedResponseMapper;
 import net.ow.movie.tmdb.feign.TMDBFeignClient;
 import net.ow.movie.tmdb.model.common.TMDBPaginatedResponse;
 import net.ow.movie.tmdb.model.movie.TMDBBaseMovie;
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Service;
 public class MovieService {
     private final TMDBFeignClient tmdbFeignClient;
 
-    private final BaseMovieDTOMapper baseMovieDTOMapper;
+    private final PaginatedResponseMapper paginatedResponseMapper;
 
     private final GenreService genreService;
 
@@ -31,7 +31,7 @@ public class MovieService {
         log.debug("Fetched now playing movies from tmdb");
 
         PaginatedResponse<BaseMovieDTO> paginatedResponse =
-                baseMovieDTOMapper.fromTMDBPaginatedBaseMovies(tmdbPaginatedResponse);
+                paginatedResponseMapper.fromTMDBPaginatedBaseMovies(tmdbPaginatedResponse);
 
         return enrichMoviesWithGenreDetails(paginatedResponse, language);
     }
@@ -44,7 +44,7 @@ public class MovieService {
         log.debug("Fetched popular movies from tmdb");
 
         PaginatedResponse<BaseMovieDTO> paginatedResponse =
-                baseMovieDTOMapper.fromTMDBPaginatedBaseMovies(tmdbPaginatedResponse);
+                paginatedResponseMapper.fromTMDBPaginatedBaseMovies(tmdbPaginatedResponse);
 
         return enrichMoviesWithGenreDetails(paginatedResponse, language);
     }

--- a/src/main/java/net/ow/movie/theatre/service/SearchService.java
+++ b/src/main/java/net/ow/movie/theatre/service/SearchService.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.ow.movie.theatre.constant.TMDBConstant;
 import net.ow.movie.theatre.dto.pagination.PaginatedResponse;
 import net.ow.movie.theatre.dto.search.SearchResultDTO;
-import net.ow.movie.theatre.mapper.search.SearchResultDTOMapper;
+import net.ow.movie.theatre.mapper.PaginatedResponseMapper;
 import net.ow.movie.tmdb.feign.TMDBFeignClient;
 import net.ow.movie.tmdb.model.common.TMDBPaginatedResponse;
 import net.ow.movie.tmdb.model.search.TMDBSearchResult;
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Service;
 public class SearchService {
     private final TMDBFeignClient tmdbFeignClient;
 
-    private final SearchResultDTOMapper searchResultDTOMapper;
+    private final PaginatedResponseMapper paginatedResponseMapper;
 
     public PaginatedResponse<SearchResultDTO> search(
             String query, Integer pageNumber, String language) {
@@ -26,6 +26,6 @@ public class SearchService {
                 tmdbFeignClient.search(query, TMDBConstant.INCLUDE_ADULT, language, pageNumber);
         log.debug("Searched \"{}\" from tmdb", query);
 
-        return searchResultDTOMapper.fromTMDBPaginatedSearchResults(tmdbPaginatedResponse);
+        return paginatedResponseMapper.fromTMDBPaginatedSearchResults(tmdbPaginatedResponse);
     }
 }

--- a/src/test/java/net/ow/movie/theatre/service/MovieServiceTest.java
+++ b/src/test/java/net/ow/movie/theatre/service/MovieServiceTest.java
@@ -10,7 +10,7 @@ import net.ow.movie.theatre.dto.genre.GenreDTO;
 import net.ow.movie.theatre.dto.movie.BaseMovieDTO;
 import net.ow.movie.theatre.dto.pagination.PaginatedResponse;
 import net.ow.movie.theatre.fixture.*;
-import net.ow.movie.theatre.mapper.movie.BaseMovieDTOMapper;
+import net.ow.movie.theatre.mapper.PaginatedResponseMapper;
 import net.ow.movie.tmdb.feign.TMDBFeignClient;
 import net.ow.movie.tmdb.model.common.TMDBDateRangePaginatedResponse;
 import net.ow.movie.tmdb.model.common.TMDBPaginatedResponse;
@@ -27,7 +27,7 @@ class MovieServiceTest {
 
     @Mock private TMDBFeignClient tmdbFeignClient;
 
-    @Mock private BaseMovieDTOMapper baseMovieDTOMapper;
+    @Mock private PaginatedResponseMapper paginatedResponseMapper;
 
     @Mock private GenreService genreService;
 
@@ -57,7 +57,7 @@ class MovieServiceTest {
 
         when(tmdbFeignClient.getNowPlayingMovies(language, page, region))
                 .thenReturn(tmdbDateRangePaginatedResponse);
-        when(baseMovieDTOMapper.fromTMDBPaginatedBaseMovies(tmdbDateRangePaginatedResponse))
+        when(paginatedResponseMapper.fromTMDBPaginatedBaseMovies(tmdbDateRangePaginatedResponse))
                 .thenReturn(paginatedResponse);
 
         when(genreService.getAllGenresAsMap(language)).thenReturn(genreIdToGenreMap);
@@ -82,7 +82,7 @@ class MovieServiceTest {
                 MockPaginatedResponse.mockPaginatedBaseMovie(Collections.emptyList());
 
         when(tmdbFeignClient.getNowPlayingMovies(language, page, region)).thenReturn(null);
-        when(baseMovieDTOMapper.fromTMDBPaginatedBaseMovies(null))
+        when(paginatedResponseMapper.fromTMDBPaginatedBaseMovies(null))
                 .thenReturn(expectedPaginatedResponse);
 
         PaginatedResponse<BaseMovieDTO> actualResponse =
@@ -109,7 +109,7 @@ class MovieServiceTest {
 
         when(tmdbFeignClient.getNowPlayingMovies(language, page, region))
                 .thenReturn(tmdbDateRangePaginatedResponse);
-        when(baseMovieDTOMapper.fromTMDBPaginatedBaseMovies(tmdbDateRangePaginatedResponse))
+        when(paginatedResponseMapper.fromTMDBPaginatedBaseMovies(tmdbDateRangePaginatedResponse))
                 .thenReturn(paginatedResponse);
 
         PaginatedResponse<BaseMovieDTO> actualResponse =
@@ -147,7 +147,7 @@ class MovieServiceTest {
 
         when(tmdbFeignClient.getPopularMovies(language, page, region))
                 .thenReturn(tmdbPaginatedResponse);
-        when(baseMovieDTOMapper.fromTMDBPaginatedBaseMovies(tmdbPaginatedResponse))
+        when(paginatedResponseMapper.fromTMDBPaginatedBaseMovies(tmdbPaginatedResponse))
                 .thenReturn(paginatedResponse);
 
         when(genreService.getAllGenresAsMap(language)).thenReturn(genreIdToGenreMap);
@@ -172,7 +172,7 @@ class MovieServiceTest {
                 MockPaginatedResponse.mockPaginatedBaseMovie(Collections.emptyList());
 
         when(tmdbFeignClient.getPopularMovies(language, page, region)).thenReturn(null);
-        when(baseMovieDTOMapper.fromTMDBPaginatedBaseMovies(null))
+        when(paginatedResponseMapper.fromTMDBPaginatedBaseMovies(null))
                 .thenReturn(expectedPaginatedResponse);
 
         PaginatedResponse<BaseMovieDTO> actualResponse =
@@ -198,7 +198,7 @@ class MovieServiceTest {
 
         when(tmdbFeignClient.getPopularMovies(language, page, region))
                 .thenReturn(tmdbPaginatedResponse);
-        when(baseMovieDTOMapper.fromTMDBPaginatedBaseMovies(tmdbPaginatedResponse))
+        when(paginatedResponseMapper.fromTMDBPaginatedBaseMovies(tmdbPaginatedResponse))
                 .thenReturn(paginatedResponse);
 
         PaginatedResponse<BaseMovieDTO> actualResponse =

--- a/src/test/java/net/ow/movie/theatre/service/SearchServiceTest.java
+++ b/src/test/java/net/ow/movie/theatre/service/SearchServiceTest.java
@@ -10,7 +10,7 @@ import net.ow.movie.theatre.dto.pagination.PaginatedResponse;
 import net.ow.movie.theatre.dto.search.SearchResultDTO;
 import net.ow.movie.theatre.fixture.MockPaginatedResponse;
 import net.ow.movie.theatre.fixture.MockTMDBPaginatedResponse;
-import net.ow.movie.theatre.mapper.search.SearchResultDTOMapper;
+import net.ow.movie.theatre.mapper.PaginatedResponseMapper;
 import net.ow.movie.tmdb.feign.TMDBFeignClient;
 import net.ow.movie.tmdb.model.common.TMDBPaginatedResponse;
 import net.ow.movie.tmdb.model.search.TMDBSearchResult;
@@ -26,7 +26,7 @@ class SearchServiceTest {
 
     @Mock private TMDBFeignClient tmdbFeignClient;
 
-    @Mock private SearchResultDTOMapper searchResultDTOMapper;
+    @Mock private PaginatedResponseMapper paginatedResponseMapper;
 
     @Test
     void searchTest_OK() {
@@ -40,7 +40,7 @@ class SearchServiceTest {
                 MockPaginatedResponse.mockPaginatedSearchResult(Collections.emptyList());
 
         when(tmdbFeignClient.search(query, true, language, page)).thenReturn(tmdbPaginatedResponse);
-        when(searchResultDTOMapper.fromTMDBPaginatedSearchResults(tmdbPaginatedResponse))
+        when(paginatedResponseMapper.fromTMDBPaginatedSearchResults(tmdbPaginatedResponse))
                 .thenReturn(paginatedResponse);
 
         PaginatedResponse<SearchResultDTO> actualPaginatedResponse =
@@ -48,7 +48,7 @@ class SearchServiceTest {
 
         assertEquals(actualPaginatedResponse, paginatedResponse);
         verify(tmdbFeignClient, times(1)).search(query, true, language, page);
-        verify(searchResultDTOMapper, times(1))
+        verify(paginatedResponseMapper, times(1))
                 .fromTMDBPaginatedSearchResults(tmdbPaginatedResponse);
     }
 
@@ -62,6 +62,6 @@ class SearchServiceTest {
 
         assertThrows(FeignException.class, () -> searchService.search(query, page, language));
         verify(tmdbFeignClient, times(1)).search(query, true, language, page);
-        verify(searchResultDTOMapper, never()).fromTMDBPaginatedSearchResults(any());
+        verify(paginatedResponseMapper, never()).fromTMDBPaginatedSearchResults(any());
     }
 }


### PR DESCRIPTION
## Description

- Migrate all PaginatedRespone related mapping from different mappers to PaginatedResponseMapper

## Checklist

- [x] I have performed a self-review of my own code
- [x] This PR does not introduce a breaking change
- [x] Unit tests are added/updated (if applicable)
- [x] No error nor warning in the console
- [ ] I have uploaded a screenshot (if applicable)

