### PR TITLE
[RFT] Refator treding tv shows api to return BaseTVShowDTO and enrich base tv show genres logic

### DIFF
--- a/src/main/java/net/ow/movie/theatre/controller/TVShowController.java
+++ b/src/main/java/net/ow/movie/theatre/controller/TVShowController.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import net.ow.movie.theatre.dto.pagination.PaginatedResponse;
-import net.ow.movie.theatre.dto.trending.TrendingTVShowDTO;
+import net.ow.movie.theatre.dto.tv.BaseTVShowDTO;
 import net.ow.movie.theatre.service.TVShowService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
@@ -21,7 +21,7 @@ public class TVShowController {
     private final TVShowService tvShowService;
 
     @GetMapping("/trending/{time_window}")
-    public ResponseEntity<PaginatedResponse<TrendingTVShowDTO>> getTrendingTVShows(
+    public ResponseEntity<PaginatedResponse<BaseTVShowDTO>> getTrendingTVShows(
             @PathVariable(value = "time_window") String timeWindow,
             @RequestParam(required = false, defaultValue = "1")
                     @Valid

--- a/src/main/java/net/ow/movie/theatre/dto/tv/BaseTVShowDTO.java
+++ b/src/main/java/net/ow/movie/theatre/dto/tv/BaseTVShowDTO.java
@@ -1,0 +1,28 @@
+package net.ow.movie.theatre.dto.tv;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import lombok.Data;
+import net.ow.movie.theatre.dto.genre.GenreDTO;
+
+@Data
+public class BaseTVShowDTO {
+    private Integer id;
+
+    private String mediaType;
+
+    private String posterPath;
+
+    private String backdropPath;
+
+    private String name;
+
+    private List<GenreDTO> genres;
+
+    private Instant releaseDate;
+
+    private String overview;
+
+    private BigDecimal rating;
+}

--- a/src/main/java/net/ow/movie/theatre/mapper/PaginatedResponseMapper.java
+++ b/src/main/java/net/ow/movie/theatre/mapper/PaginatedResponseMapper.java
@@ -3,7 +3,6 @@ package net.ow.movie.theatre.mapper;
 import net.ow.movie.theatre.dto.pagination.PaginatedResponse;
 import net.ow.movie.theatre.dto.search.SearchResultDTO;
 import net.ow.movie.theatre.dto.trending.TrendingDTO;
-import net.ow.movie.theatre.dto.trending.TrendingTVShowDTO;
 import net.ow.movie.theatre.mapper.movie.BaseMovieDTOMapper;
 import net.ow.movie.theatre.mapper.search.SearchResultDTOMapper;
 import net.ow.movie.theatre.mapper.trending.TrendingDTOMapper;
@@ -12,7 +11,6 @@ import net.ow.movie.theatre.mapper.trending.TrendingTVShowDTOMapper;
 import net.ow.movie.tmdb.model.common.TMDBPaginatedResponse;
 import net.ow.movie.tmdb.model.search.TMDBSearchResult;
 import net.ow.movie.tmdb.model.trending.TMDBTrending;
-import net.ow.movie.tmdb.model.trending.TMDBTrendingTVShow;
 import org.mapstruct.*;
 
 @Mapper(
@@ -38,9 +36,4 @@ public interface PaginatedResponseMapper {
     @Mapping(target = "total", source = "totalResults")
     PaginatedResponse<TrendingDTO> fromTMDBPaginatedTrending(
             TMDBPaginatedResponse<TMDBTrending> tmdbPaginatedResponse);
-
-    @Mapping(target = "data", source = "results")
-    @Mapping(target = "total", source = "totalResults")
-    PaginatedResponse<TrendingTVShowDTO> fromTMDBPaginatedTrendingTVShows(
-            TMDBPaginatedResponse<TMDBTrendingTVShow> tmdbPaginatedResponse);
 }

--- a/src/main/java/net/ow/movie/theatre/mapper/tv/BaseTVShowDTOMapper.java
+++ b/src/main/java/net/ow/movie/theatre/mapper/tv/BaseTVShowDTOMapper.java
@@ -1,0 +1,27 @@
+package net.ow.movie.theatre.mapper.tv;
+
+import net.ow.movie.theatre.dto.pagination.PaginatedResponse;
+import net.ow.movie.theatre.dto.tv.BaseTVShowDTO;
+import net.ow.movie.theatre.mapper.genre.GenreDTOMapper;
+import net.ow.movie.tmdb.model.common.TMDBPaginatedResponse;
+import net.ow.movie.tmdb.model.trending.TMDBTrendingTVShow;
+import org.mapstruct.*;
+
+@Mapper(
+        componentModel = "spring",
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+        nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT,
+        nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT,
+        unmappedTargetPolicy = ReportingPolicy.IGNORE,
+        uses = {GenreDTOMapper.class})
+public interface BaseTVShowDTOMapper {
+    @Mapping(target = "releaseDate", source = "firstAirDate")
+    @Mapping(target = "genres", source = "genreIds")
+    @Mapping(target = "rating", source = "voteAverage")
+    BaseTVShowDTO fromTMDBTrendingTVShow(TMDBTrendingTVShow tmdbTrendingTVShow);
+
+    @Mapping(target = "data", source = "results")
+    @Mapping(target = "total", source = "totalResults")
+    PaginatedResponse<BaseTVShowDTO> fromTMDBPaginatedTrendingTVShows(
+            TMDBPaginatedResponse<TMDBTrendingTVShow> tmdbPaginatedResponse);
+}

--- a/src/main/java/net/ow/movie/theatre/service/TVShowService.java
+++ b/src/main/java/net/ow/movie/theatre/service/TVShowService.java
@@ -2,12 +2,13 @@ package net.ow.movie.theatre.service;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.ow.movie.theatre.dto.genre.GenreDTO;
 import net.ow.movie.theatre.dto.pagination.PaginatedResponse;
-import net.ow.movie.theatre.dto.trending.TrendingTVShowDTO;
-import net.ow.movie.theatre.mapper.PaginatedResponseMapper;
+import net.ow.movie.theatre.dto.tv.BaseTVShowDTO;
+import net.ow.movie.theatre.mapper.tv.BaseTVShowDTOMapper;
 import net.ow.movie.tmdb.feign.TMDBFeignClient;
 import net.ow.movie.tmdb.model.common.TMDBPaginatedResponse;
 import net.ow.movie.tmdb.model.trending.TMDBTrendingTVShow;
@@ -21,37 +22,33 @@ public class TVShowService {
 
     private final GenreService genreService;
 
-    private final PaginatedResponseMapper paginatedResponseMapper;
+    private final BaseTVShowDTOMapper paginatedResponseMapper;
 
-    public PaginatedResponse<TrendingTVShowDTO> getTrendingTVShows(
+    public PaginatedResponse<BaseTVShowDTO> getTrendingTVShows(
             String timeWindow, Integer page, String language) {
         log.debug("Fetching trending TV shows from TMDB");
         TMDBPaginatedResponse<TMDBTrendingTVShow> tmdbPaginatedResponse =
                 tmdbFeignClient.getTrendingTVShows(timeWindow, language, page);
         log.debug("Fetched trending TV shows from TMDB");
 
-        PaginatedResponse<TrendingTVShowDTO> paginatedResponse =
+        PaginatedResponse<BaseTVShowDTO> paginatedResponse =
                 paginatedResponseMapper.fromTMDBPaginatedTrendingTVShows(tmdbPaginatedResponse);
 
-        return enrichTrendingTVShowWithGenreDetails(paginatedResponse, language);
-    }
-
-    private PaginatedResponse<TrendingTVShowDTO> enrichTrendingTVShowWithGenreDetails(
-            PaginatedResponse<TrendingTVShowDTO> paginatedResponse, String language) {
         // NOTE: When fetching trending tv show from TMDB,
         // only ids are included in the response for genres.
         Map<Integer, GenreDTO> genreIdToGenreMap = genreService.getTVShowGenresAsMap(language);
         paginatedResponse
                 .getData()
-                .forEach(
-                        tvShow -> {
-                            List<Integer> genreIds =
-                                    tvShow.getGenres().stream().map(GenreDTO::getId).toList();
-                            List<GenreDTO> genres =
-                                    genreIds.stream().map(genreIdToGenreMap::get).toList();
-                            tvShow.setGenres(genres);
-                        });
+                .forEach(tvShow -> enrichBaseTVShowWithGenres(tvShow, genreIdToGenreMap));
 
         return paginatedResponse;
+    }
+
+    private void enrichBaseTVShowWithGenres(
+            BaseTVShowDTO baseTVShow, Map<Integer, GenreDTO> genreIdToGenreMap) {
+        List<Integer> genreIds = baseTVShow.getGenres().stream().map(GenreDTO::getId).toList();
+        List<GenreDTO> genres =
+                genreIds.stream().map(genreIdToGenreMap::get).filter(Objects::nonNull).toList();
+        baseTVShow.setGenres(genres);
     }
 }

--- a/src/test/java/net/ow/movie/theatre/fixture/MockBaseTVShowDTO.java
+++ b/src/test/java/net/ow/movie/theatre/fixture/MockBaseTVShowDTO.java
@@ -1,0 +1,17 @@
+package net.ow.movie.theatre.fixture;
+
+import java.util.List;
+import net.ow.movie.theatre.dto.genre.GenreDTO;
+import net.ow.movie.theatre.dto.tv.BaseTVShowDTO;
+
+public class MockBaseTVShowDTO {
+    public static BaseTVShowDTO mock(Integer id, String name, List<GenreDTO> genres) {
+        BaseTVShowDTO baseTVShow = new BaseTVShowDTO();
+
+        baseTVShow.setId(id);
+        baseTVShow.setName(name);
+        baseTVShow.setGenres(genres);
+
+        return baseTVShow;
+    }
+}

--- a/src/test/java/net/ow/movie/theatre/fixture/MockPaginatedResponse.java
+++ b/src/test/java/net/ow/movie/theatre/fixture/MockPaginatedResponse.java
@@ -7,10 +7,23 @@ import net.ow.movie.theatre.dto.search.SearchResultDTO;
 import net.ow.movie.theatre.dto.trending.TrendingDTO;
 import net.ow.movie.theatre.dto.trending.TrendingMovieDTO;
 import net.ow.movie.theatre.dto.trending.TrendingTVShowDTO;
+import net.ow.movie.theatre.dto.tv.BaseTVShowDTO;
 
 public class MockPaginatedResponse {
     public static PaginatedResponse<TrendingDTO> mockPaginatedTrending(List<TrendingDTO> data) {
         PaginatedResponse<TrendingDTO> paginatedResponse = new PaginatedResponse<>();
+
+        paginatedResponse.setData(data);
+        paginatedResponse.setPage(1);
+        paginatedResponse.setTotalPages(1);
+        paginatedResponse.setTotal(null == data ? 0 : data.size());
+
+        return paginatedResponse;
+    }
+
+    public static PaginatedResponse<BaseTVShowDTO> mockPaginatedBaseTVShowDTO(
+            List<BaseTVShowDTO> data) {
+        PaginatedResponse<BaseTVShowDTO> paginatedResponse = new PaginatedResponse<>();
 
         paginatedResponse.setData(data);
         paginatedResponse.setPage(1);

--- a/src/test/java/net/ow/movie/theatre/service/TVShowServiceTest.java
+++ b/src/test/java/net/ow/movie/theatre/service/TVShowServiceTest.java
@@ -9,9 +9,9 @@ import java.util.List;
 import java.util.Map;
 import net.ow.movie.theatre.dto.genre.GenreDTO;
 import net.ow.movie.theatre.dto.pagination.PaginatedResponse;
-import net.ow.movie.theatre.dto.trending.TrendingTVShowDTO;
+import net.ow.movie.theatre.dto.tv.BaseTVShowDTO;
 import net.ow.movie.theatre.fixture.*;
-import net.ow.movie.theatre.mapper.PaginatedResponseMapper;
+import net.ow.movie.theatre.mapper.tv.BaseTVShowDTOMapper;
 import net.ow.movie.tmdb.feign.TMDBFeignClient;
 import net.ow.movie.tmdb.model.common.TMDBPaginatedResponse;
 import net.ow.movie.tmdb.model.trending.TMDBTrendingTVShow;
@@ -27,7 +27,7 @@ class TVShowServiceTest {
 
     @Mock private TMDBFeignClient tmdbFeignClient;
 
-    @Mock private PaginatedResponseMapper paginatedResponseMapper;
+    @Mock private BaseTVShowDTOMapper baseTVShowDTOMapper;
 
     @Mock private GenreService genreService;
 
@@ -44,11 +44,11 @@ class TVShowServiceTest {
 
         Integer tvShowId = 1;
         String tvShowName = "tv-show-name";
-        TrendingTVShowDTO tvShow =
-                MockTrendingTVShowDTO.mock(
+        BaseTVShowDTO tvShow =
+                MockBaseTVShowDTO.mock(
                         tvShowId, tvShowName, List.of(MockGenreDTO.mock(genreId, null)));
-        PaginatedResponse<TrendingTVShowDTO> paginatedResponse =
-                MockPaginatedResponse.mockPaginatedTrendingTVShow(List.of(tvShow));
+        PaginatedResponse<BaseTVShowDTO> paginatedResponse =
+                MockPaginatedResponse.mockPaginatedBaseTVShowDTO(List.of(tvShow));
 
         TMDBTrendingTVShow trendingTVShow = MockTMDBTrendingTVShow.mock(tvShowId);
         TMDBPaginatedResponse<TMDBTrendingTVShow> tmdbPaginatedResponse =
@@ -56,12 +56,12 @@ class TVShowServiceTest {
 
         when(tmdbFeignClient.getTrendingTVShows(timeWindow, language, page))
                 .thenReturn(tmdbPaginatedResponse);
-        when(paginatedResponseMapper.fromTMDBPaginatedTrendingTVShows(tmdbPaginatedResponse))
+        when(baseTVShowDTOMapper.fromTMDBPaginatedTrendingTVShows(tmdbPaginatedResponse))
                 .thenReturn(paginatedResponse);
 
         when(genreService.getTVShowGenresAsMap(language)).thenReturn(genreIdToGenreMap);
 
-        PaginatedResponse<TrendingTVShowDTO> actualResponse =
+        PaginatedResponse<BaseTVShowDTO> actualResponse =
                 tvShowService.getTrendingTVShows(timeWindow, page, language);
 
         assertNotNull(actualResponse);
@@ -77,14 +77,14 @@ class TVShowServiceTest {
         String language = "zh-CN";
         Integer page = 1;
 
-        PaginatedResponse<TrendingTVShowDTO> expectedPaginatedResponse =
-                MockPaginatedResponse.mockPaginatedTrendingTVShow(Collections.emptyList());
+        PaginatedResponse<BaseTVShowDTO> expectedPaginatedResponse =
+                MockPaginatedResponse.mockPaginatedBaseTVShowDTO(Collections.emptyList());
 
         when(tmdbFeignClient.getTrendingTVShows(timeWindow, language, page)).thenReturn(null);
-        when(paginatedResponseMapper.fromTMDBPaginatedTrendingTVShows(null))
+        when(baseTVShowDTOMapper.fromTMDBPaginatedTrendingTVShows(null))
                 .thenReturn(expectedPaginatedResponse);
 
-        PaginatedResponse<TrendingTVShowDTO> actualResponse =
+        PaginatedResponse<BaseTVShowDTO> actualResponse =
                 tvShowService.getTrendingTVShows(timeWindow, page, language);
 
         assertTrue(actualResponse.getData().isEmpty());
@@ -102,15 +102,15 @@ class TVShowServiceTest {
         TMDBPaginatedResponse<TMDBTrendingTVShow> tmdbPaginatedResponse =
                 MockTMDBPaginatedResponse.mockTMDBPaginatedTrendingTVShow(Collections.emptyList());
 
-        PaginatedResponse<TrendingTVShowDTO> expectedPaginatedResponse =
-                MockPaginatedResponse.mockPaginatedTrendingTVShow(Collections.emptyList());
+        PaginatedResponse<BaseTVShowDTO> expectedPaginatedResponse =
+                MockPaginatedResponse.mockPaginatedBaseTVShowDTO(Collections.emptyList());
 
         when(tmdbFeignClient.getTrendingTVShows(timeWindow, language, page))
                 .thenReturn(tmdbPaginatedResponse);
-        when(paginatedResponseMapper.fromTMDBPaginatedTrendingTVShows(tmdbPaginatedResponse))
+        when(baseTVShowDTOMapper.fromTMDBPaginatedTrendingTVShows(tmdbPaginatedResponse))
                 .thenReturn(expectedPaginatedResponse);
 
-        PaginatedResponse<TrendingTVShowDTO> actualResponse =
+        PaginatedResponse<BaseTVShowDTO> actualResponse =
                 tvShowService.getTrendingTVShows(timeWindow, page, language);
 
         assertTrue(actualResponse.getData().isEmpty());


### PR DESCRIPTION
## Description

- Refator treding tv shows api to return BaseTVShowDTO
- Refator enrich base tv show genres logic

## Screenshot / Video
![截屏2025-04-06 00 41 58](https://github.com/user-attachments/assets/58da650c-b100-476e-8443-6add7b0cbfa0)

## Checklist

- [x] I have performed a self-review of my own code
- [x] This PR does not introduce a breaking change
- [x] Unit tests are added/updated (if applicable)
- [x] No error nor warning in the console
- [x] I have uploaded a screenshot (if applicable)

