### PR TITLE
[RFT] Remove get now playing movies api

### DIFF
--- a/src/main/java/net/ow/movie/theatre/controller/MovieController.java
+++ b/src/main/java/net/ow/movie/theatre/controller/MovieController.java
@@ -21,18 +21,6 @@ import org.springframework.web.bind.annotation.*;
 public class MovieController {
     private final MovieService movieService;
 
-    @GetMapping("/now-playing")
-    public ResponseEntity<PaginatedResponse<BaseMovieDTO>> getNowPlayingMovies(
-            @RequestParam(required = false) String region,
-            @RequestParam(required = false, defaultValue = "1")
-                    @Valid
-                    @Min(value = 1, message = "Page must be at least 1")
-                    @Max(value = 500, message = "Page must be less then 500")
-                    Integer page,
-            @RequestHeader(value = HttpHeaders.ACCEPT_LANGUAGE) String language) {
-        return ResponseEntity.ok(movieService.getNowPlayingMovies(language, page, region));
-    }
-
     @GetMapping("/trending")
     public ResponseEntity<PaginatedResponse<BaseMovieDTO>> getTrendingMovies(
             @RequestParam(value = "time_window") String timeWindow,

--- a/src/main/java/net/ow/movie/theatre/service/MovieService.java
+++ b/src/main/java/net/ow/movie/theatre/service/MovieService.java
@@ -16,7 +16,6 @@ import net.ow.movie.theatre.mapper.movie.BaseMovieDTOMapper;
 import net.ow.movie.theatre.mapper.movie.MovieDTOMapper;
 import net.ow.movie.tmdb.feign.TMDBFeignClient;
 import net.ow.movie.tmdb.model.common.TMDBPaginatedResponse;
-import net.ow.movie.tmdb.model.movie.TMDBBaseMovie;
 import net.ow.movie.tmdb.model.movie.TMDBMovie;
 import net.ow.movie.tmdb.model.trending.TMDBTrendingMovie;
 import org.springframework.stereotype.Service;
@@ -42,24 +41,6 @@ public class MovieService {
                 baseMovieDTOMapper.fromTMDBPaginatedTrendingMovies(tmdbPaginatedResponse);
 
         // NOTE: When fetching trending movies from TMDB,
-        // only ids are included in the response for genres.
-        Map<Integer, GenreDTO> genreIdToGenreMap = genreService.getMovieGenresAsMap(language);
-        paginatedResponse
-                .getData()
-                .forEach(movie -> enrichBaseMovieWithGenres(movie, genreIdToGenreMap));
-
-        return paginatedResponse;
-    }
-
-    public PaginatedResponse<BaseMovieDTO> getNowPlayingMovies(
-            String language, Integer page, String region) {
-        TMDBPaginatedResponse<TMDBBaseMovie> tmdbPaginatedResponse =
-                tmdbFeignClient.getNowPlayingMovies(language, page, region);
-
-        PaginatedResponse<BaseMovieDTO> paginatedResponse =
-                baseMovieDTOMapper.fromTMDBPaginatedBaseMovies(tmdbPaginatedResponse);
-
-        // NOTE: When fetching now playing movies from TMDB,
         // only ids are included in the response for genres.
         Map<Integer, GenreDTO> genreIdToGenreMap = genreService.getMovieGenresAsMap(language);
         paginatedResponse

--- a/src/main/resources/api-doc/movie-theatre-service.yaml
+++ b/src/main/resources/api-doc/movie-theatre-service.yaml
@@ -109,51 +109,6 @@ paths:
         '500':
           description: Internal server error
 
-  /movies/now-playing:
-    get:
-      tags:
-        - Movies
-      summary: Get now playing movies
-      description: Retrieves a paginated list of movies currently playing in theaters
-      operationId: getNowPlayingMovies
-      parameters:
-        - name: region
-          in: query
-          description: Region code for filtering movies (e.g., US, FR)
-          required: false
-          schema:
-            type: string
-        - name: page
-          in: query
-          description: Page number for paginated results
-          required: false
-          schema:
-            type: integer
-            default: 1
-            minimum: 1
-            maximum: 500
-        - name: Accept-Language
-          in: header
-          description: Language code for localized results (e.g., en-US, fr-FR)
-          required: true
-          schema:
-            type: string
-      responses:
-        '200':
-          description: Successful operation
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/PaginatedResponseBaseMovieDTO'
-        '400':
-          description: Bad request - Invalid parameters
-        '401':
-          description: Unauthorized - Authentication is required
-        '403':
-          description: Forbidden - Insufficient permissions to access this resource
-        '500':
-          description: Internal server error
-
   /movies/trending:
     get:
       tags:

--- a/src/test/java/net/ow/movie/theatre/service/MovieServiceTest.java
+++ b/src/test/java/net/ow/movie/theatre/service/MovieServiceTest.java
@@ -14,9 +14,7 @@ import net.ow.movie.theatre.fixture.*;
 import net.ow.movie.theatre.mapper.movie.BaseMovieDTOMapper;
 import net.ow.movie.theatre.mapper.movie.MovieDTOMapper;
 import net.ow.movie.tmdb.feign.TMDBFeignClient;
-import net.ow.movie.tmdb.model.common.TMDBDateRangePaginatedResponse;
 import net.ow.movie.tmdb.model.common.TMDBPaginatedResponse;
-import net.ow.movie.tmdb.model.movie.TMDBBaseMovie;
 import net.ow.movie.tmdb.model.movie.TMDBMovie;
 import net.ow.movie.tmdb.model.trending.TMDBTrendingMovie;
 import net.ow.shared.errorutils.model.APIException;
@@ -121,97 +119,6 @@ class MovieServiceTest {
         PaginatedResponse<BaseMovieDTO> actualResponse =
                 movieService.getTrendingMovies(timeWindow, language, page);
 
-        assertTrue(actualResponse.getData().isEmpty());
-        assertEquals(1, actualResponse.getPage());
-        assertEquals(1, actualResponse.getTotalPages());
-        assertEquals(0, actualResponse.getTotal());
-    }
-
-    @Test
-    void getNowPlayingMoviesTest_OK() {
-        String language = "zh-CN";
-        Integer page = 1;
-        String region = "CH";
-
-        Integer genreId = 1;
-        String genreName = "genre-name";
-        GenreDTO genre = MockGenreDTO.mock(genreId, genreName);
-        Map<Integer, GenreDTO> genreIdToGenreMap = Collections.singletonMap(genreId, genre);
-
-        Integer movieId = 1;
-        String movieName = "movie-name";
-        BaseMovieDTO movie =
-                MockBaseMovieDTO.mock(
-                        movieId, movieName, List.of(MockGenreDTO.mock(genreId, null)));
-        PaginatedResponse<BaseMovieDTO> paginatedResponse =
-                MockPaginatedResponse.mockPaginatedBaseMovieDTO(List.of(movie));
-
-        TMDBBaseMovie tmdbBaseMovie = MockTMDBBaseMovie.mock(movieId);
-        TMDBDateRangePaginatedResponse<TMDBBaseMovie> tmdbDateRangePaginatedResponse =
-                MockDateRangePaginatedResponse.mockDateRangePaginatedTMDBBaseMovie(
-                        List.of(tmdbBaseMovie));
-
-        when(tmdbFeignClient.getNowPlayingMovies(language, page, region))
-                .thenReturn(tmdbDateRangePaginatedResponse);
-        when(baseMovieDTOMapper.fromTMDBPaginatedBaseMovies(tmdbDateRangePaginatedResponse))
-                .thenReturn(paginatedResponse);
-
-        when(genreService.getMovieGenresAsMap(language)).thenReturn(genreIdToGenreMap);
-
-        PaginatedResponse<BaseMovieDTO> actualResponse =
-                movieService.getNowPlayingMovies(language, page, region);
-
-        assertNotNull(actualResponse);
-
-        assertFalse(actualResponse.getData().isEmpty());
-        assertEquals(1, actualResponse.getPage());
-        assertEquals(genre, movie.getGenres().get(0));
-    }
-
-    @Test
-    void getNowPlayingMoviesTest_whenNullTMDBResponse_thenReturnsEmptyPaginatedResponse() {
-        String language = "zh-CN";
-        Integer page = 1;
-        String region = "CH";
-
-        PaginatedResponse<BaseMovieDTO> expectedPaginatedResponse =
-                MockPaginatedResponse.mockPaginatedBaseMovieDTO(Collections.emptyList());
-
-        when(tmdbFeignClient.getNowPlayingMovies(language, page, region)).thenReturn(null);
-        when(baseMovieDTOMapper.fromTMDBPaginatedBaseMovies(null))
-                .thenReturn(expectedPaginatedResponse);
-
-        PaginatedResponse<BaseMovieDTO> actualResponse =
-                movieService.getNowPlayingMovies(language, page, region);
-
-        assertTrue(actualResponse.getData().isEmpty());
-        assertEquals(1, actualResponse.getPage());
-        assertEquals(1, actualResponse.getTotalPages());
-        assertEquals(0, actualResponse.getTotal());
-    }
-
-    @Test
-    void getNowPlayingMoviesTest_whenTMDBEmptyData_thenReturnsEmptyPaginatedResponse() {
-        String language = "zh-CN";
-        Integer page = 1;
-        String region = "CH";
-
-        PaginatedResponse<BaseMovieDTO> paginatedResponse =
-                MockPaginatedResponse.mockPaginatedBaseMovieDTO(Collections.emptyList());
-
-        TMDBDateRangePaginatedResponse<TMDBBaseMovie> tmdbDateRangePaginatedResponse =
-                MockDateRangePaginatedResponse.mockDateRangePaginatedTMDBBaseMovie(
-                        Collections.emptyList());
-
-        when(tmdbFeignClient.getNowPlayingMovies(language, page, region))
-                .thenReturn(tmdbDateRangePaginatedResponse);
-        when(baseMovieDTOMapper.fromTMDBPaginatedBaseMovies(tmdbDateRangePaginatedResponse))
-                .thenReturn(paginatedResponse);
-
-        PaginatedResponse<BaseMovieDTO> actualResponse =
-                movieService.getNowPlayingMovies(language, page, region);
-
-        assertNotNull(actualResponse);
         assertTrue(actualResponse.getData().isEmpty());
         assertEquals(1, actualResponse.getPage());
         assertEquals(1, actualResponse.getTotalPages());


### PR DESCRIPTION
## Description

- Remove get nw playing movies api

## Screenshot / Video
![截屏2025-05-27 19 18 19](https://github.com/user-attachments/assets/0172c11f-2038-4abe-af01-b911ae2d60de)

## Checklist

- [x] I have performed a self-review of my own code
- [ ] This PR does not introduce a breaking change
- [x] Unit tests are added/updated (if applicable)
- [x] No error nor warning in the console
- [x] I have uploaded a screenshot (if applicable)

